### PR TITLE
change the uint64_t to unsigned long long to avoid conflict in gcc

### DIFF
--- a/emp-ag2pc/helper.h
+++ b/emp-ag2pc/helper.h
@@ -13,20 +13,20 @@ using std::flush;
 namespace emp {
 
 void send_bool_aligned(NetIO* io, const bool * data, int length) {
-	uint64_t * data64 = (uint64_t * )data;
+	unsigned long long * data64 = (unsigned long long * )data;
 	int i = 0;
 	for(; i < length/8; ++i) {
-		uint64_t tmp = _pext_u64(data64[i], 0x0101010101010101ULL);
+		unsigned long long tmp = _pext_u64(data64[i], 0x0101010101010101ULL);
 		io->send_data(&tmp, 1);
 	}
 	if (8*i != length)
 		io->send_data(data + 8*i, length - 8*i);
 }
 void recv_bool_aligned(NetIO* io, bool * data, int length) {
-	uint64_t * data64 = (uint64_t *) data;
+	unsigned long long * data64 = (unsigned long long *) data;
 	int i = 0;
 	for(; i < length/8; ++i) {
-		uint64_t tmp = 0;
+		unsigned long long tmp = 0;
 		io->recv_data(&tmp, 1);
 		data64[i] = _pdep_u64(tmp, 0x0101010101010101ULL);
 	}


### PR DESCRIPTION
GCC resolves uint64_t to unsigned long when the word size is 64 bits.
https://stackoverflow.com/questions/32198368/unsigned-long-long-conflict-with-uint64-t

to resolve this problem, uint64_t is avoided in helper.h

Now Travis is happy again https://travis-ci.org/weikengchen/emp-ag2pc