### PR TITLE
Make input const in `2pc.h`

### DIFF
--- a/emp-ag2pc/2pc.h
+++ b/emp-ag2pc/2pc.h
@@ -271,7 +271,7 @@ class C2PC { public:
 		io->flush();
 	}
 
-	void online (bool * input, bool * output, bool alice_output = false) {
+	void online (const bool * input, bool * output, bool alice_output = false) {
 		uint8_t * mask_input = new uint8_t[cf->num_wire];
 		memset(mask_input, 0, cf->num_wire);
 		block tmp;


### PR DESCRIPTION
At the moment it's impossible to write this:

```c++
void do_garbling(const bool * const in, ...) {
  // Assume the 2pc object is called twopc
  bool out[128];
  twopc.online(in, out, false);
}
```

This is because `in` is not marked as `const` in `2pc.h`:

```c++
void online(bool * input, bool * output, bool alice_output = false) { ...}
```

This PR just marks `input` as `const`. This doesn't affect the behaviour of the function at all, as `input` was already implicitly `const` (i.e it's never actually written to).