### PR TITLE
Replace "1" with "ALICE".

### DIFF
--- a/emp-ag2pc/fpre.h
+++ b/emp-ag2pc/fpre.h
@@ -142,7 +142,7 @@ class Fpre {
 			}
 			joinNclean(res);
 
-			if(party == 1) {
+			if(party == ALICE) {
 				cout <<"ABIT\t"<<time_from(start_time)<<"\n";
 				start_time = clock_start();
 			}
@@ -156,7 +156,7 @@ class Fpre {
 				}));
 			}
 			joinNclean(res);
-			if(party == 1) {
+			if(party == ALICE) {
 				cout <<"check\t"<<time_from(start_time)<<"\n";
 				start_time = clock_start();
 			}
@@ -178,7 +178,7 @@ class Fpre {
 				}
 				joinNclean(res);
 			}
-			if(party == 1) {
+			if(party == ALICE) {
 				cout <<"permute\t"<<time_from(start_time)<<"\n";
 				start_time = clock_start();
 			}


### PR DESCRIPTION
It looks like ```fpre.h``` was using `1` in place of ```Alice``` in some places. This should hopefully make it easier to spot bugs if the definition of ```Alice``` ever changes from `1`.