### PR TITLE
Remove check on nullptr before delete

### DIFF
--- a/emp-ag2pc/fpre.h
+++ b/emp-ag2pc/fpre.h
@@ -103,10 +103,10 @@ class Fpre {
 				permute_batch_size = 3100;
 			}
 			else bucket_size = 5;
-			if (MAC != nullptr) {
-				delete[] MAC;
-				delete[] KEY;
-			}
+			
+			delete[] MAC;
+			delete[] KEY;
+	      
 			MAC = new block[batch_size * bucket_size * 3];
 			KEY = new block[batch_size * bucket_size * 3];
 			MAC_res = new block[batch_size * 3];
@@ -114,12 +114,11 @@ class Fpre {
 //			cout << size<<"\t"<<batch_size<<"\n";
 		}
 		~Fpre() {
-			if(MAC != nullptr) {
-				delete[] MAC;
-				delete[] KEY;
-			}
-			if (MAC_res != nullptr) delete[] MAC_res;
-			if (KEY_res != nullptr) delete[] KEY_res;
+
+			delete[] MAC;
+		        delete[] KEY;
+			delete[] MAC_res;
+			delete[] KEY_res;
 			delete[] prps;
 			delete pool;
 			for(int i = 0; i < THDS; ++i) {


### PR DESCRIPTION
The C++ standard states that it is safe to call ```delete``` and ```delete[]``` on null pointers:

```
The value of the first argument supplied to a deallocation function may be a null pointer value; if so, and if the deallocation
function is one supplied in the standard library, the call has no effect. 
```

See [§3.7.4.2 paragraph 3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf) on Page 64.

This PR just removes the null pointer checks surrounding calls to ```delete``` and ```delete[]```, since they're superfluous.

It's possible that I've misunderstood why these checks are in the code in the first place, so if I've misunderstood their role then apologies :) 