### PR TITLE
Fix memory leak

### DIFF
--- a/emp-ag2pc/fpre.h
+++ b/emp-ag2pc/fpre.h
@@ -127,6 +127,7 @@ class Fpre {
 				delete io[i];
 				delete io2[i];
 				delete eq[i];
+                                delete eq[THDS + i];
 			}
 		}
 		void refill() {


### PR DESCRIPTION
At the moment ```fpre.h``` leaks memory allocated in the constructor. Specifically, the constructor allocates memory like this:

```c++
for(int i = 0; i < THDS; ++i) {
      ...
      eq[i] = new Feq<T>(io[i], party);
      eq[THDS + i] = new Feq<T>(io2[i], party);
}
```

Whereas the destructor only frees the first half:

```c++
for(int i = 0; i < THDS; ++i) {
  ...
  delete eq[i];
}
```

This PR simply deletes the rest of the `eq` values. AddressSanitizer doesn't show any other leaks, so I think this is the only one.  