### PR TITLE
Fix CMake find_package warning

### DIFF
--- a/cmake/emp-ag2pc-config.cmake
+++ b/cmake/emp-ag2pc-config.cmake
@@ -4,7 +4,7 @@ find_path(EMP-AG2PC_INCLUDE_DIR emp-ag2pc/emp-ag2pc.h)
 
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(EMP-AG2PC DEFAULT_MSG EMP-AG2PC_INCLUDE_DIR)
+find_package_handle_standard_args(emp-ag2pc DEFAULT_MSG EMP-AG2PC_INCLUDE_DIR)
 
 if(EMP-AG2PC_FOUND)
 	set(EMP-AG2PC_INCLUDE_DIRS ${EMP-AG2PC_INCLUDE_DIR} ${EMP-OT_INCLUDE_DIRS})


### PR DESCRIPTION
```
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (EMP-AG2PC)
  does not match the name of the calling package (emp-ag2pc).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  <...>/prefix-emptool-host/cmake/emp-ag2pc-config.cmake:7 (find_package_handle_standard_args)
  CMakeLists.txt:11 (FIND_PACKAGE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```