### PR TITLE
backend: use unaligned PRG output for 32-bit bucket coin

### DIFF
--- a/emp-ag2pc/backend/triple_pool.h
+++ b/emp-ag2pc/backend/triple_pool.h
@@ -399,7 +399,7 @@ public:
       block S = RO("AG2PC RO", zero_block)
                     .absorb(io->get_digest()).absorb(sib->get_digest()).squeeze_block();
       uint32_t raw;
-      { PRG prg2(&S); prg2.random_data(&raw, sizeof(uint32_t)); }
+      { PRG prg2(&S); prg2.random_data_unaligned(&raw, sizeof(uint32_t)); }
       int r_k = (int)(raw % (uint32_t)L);
       bucket_one_layer(am, ak, sac_mac.data(), sac_key.data(), L, r_k);
     }


### PR DESCRIPTION
## Summary

This fixes a Debug-build abort in `TriplePool::layered_bucket_into_acc` by using `PRG::random_data_unaligned` for the per-layer cyclic-shift coin draw.

The code draws four bytes into a stack `uint32_t raw`. `PRG::random_data` requires its destination pointer to be 16-byte aligned, but a `uint32_t` object is not guaranteed to satisfy that alignment. Debug builds hit emp-tool's alignment assert and abort.

The fix changes this 4-byte draw from `random_data` to `random_data_unaligned`, which is the API intended for destinations without 16-byte alignment.

## Details

`layered_bucket_into_acc` derives a public per-layer cyclic-shift coin by hashing the channel digests into a seed block, initializing a local `PRG`, and drawing a `uint32_t` used as `raw % L`.

Before:

```cpp
uint32_t raw;
{ PRG prg2(&S); prg2.random_data(&raw, sizeof(uint32_t)); }
```

After:

```cpp
uint32_t raw;
{ PRG prg2(&S); prg2.random_data_unaligned(&raw, sizeof(uint32_t)); }
```

This preserves the protocol behavior while removing the invalid alignment assumption. Release builds may not abort because the check is an assert, but the old call still violated the `PRG::random_data` precondition.

## Reproduction

The failure reproduces on the parent commit with a Debug build:

```bash
cmake -S . -B build-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/path/to/emp-prefix
cmake --build build-debug -j$(nproc)
./run ./build-debug/bin/test_context_api
```

The fixed commit passes the same test under the same build configuration.

## Validation

The fixed commit passes these Debug tests:

```bash
./run ./build-debug/bin/test_context_api
./run ./build-debug/bin/test_direct_chunks
./run ./build-debug/bin/test_program_replay
./run ./build-debug/bin/test_body_replay_equiv
```

<details>
<summary>Crash log from the parent commit</summary>

```text
test_context_api: emp-tool/runtime/crypto/prg.h:92: void emp::PRG::random_data(void*, int64_t): Assertion `((uintptr_t)data & (alignof(block) - 1)) == 0 && "random_data requires 16-byte aligned data; use random_data_unaligned"' failed.
test_context_api: emp-tool/runtime/crypto/prg.h:92: void emp::PRG::random_data(void*, int64_t): Assertion `((uintptr_t)data & (alignof(block) - 1)) == 0 && "random_data requires 16-byte aligned data; use random_data_unaligned"' failed.
./run: line 8: Aborted                 "$1" 2 "$PORT" "${@:2}"
./run: line 8: Aborted                 "$1" 1 "$PORT" "${@:2}"
```

</details>

<details>
<summary>Backtrace from the parent commit</summary>

```text
#4  emp::PRG::random_data(void*, long) at emp-tool/runtime/crypto/prg.h:92
#5  TriplePool::layered_bucket_into_acc(...) at emp-ag2pc/backend/triple_pool.h:402
#6  TriplePool::compute_inplace(...) at emp-ag2pc/backend/triple_pool.h:446
#7  emp::AG2PCEngine::run_source(...) at emp-ag2pc/backend/engine.h:175
#8  emp::AG2PCEngine::run_program(...) at emp-ag2pc/backend/engine.h:240
#9  emp::AG2PCSession::flush_(...) at emp-ag2pc/session/ag2pc_session.h:394
#10 emp::AG2PCSession::reveal<emp::UInt_T<emp::AG2PCCtx, 32>>(...) at emp-ag2pc/session/ag2pc_session.h:153
#11 main(...) at test/test_context_api.cpp:29
```

</details>
